### PR TITLE
Use devDependencies to avoid unnecessary dependencies in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A distributed maintained collection of patterns that indicate that something probably is secret",
   "main": "index.js",
-  "dependencies": {
+  "devDependencies": {
     "standard": "^8.5.0",
     "tape": "^4.6.2"
   },


### PR DESCRIPTION
is-secret's two dependencies are only needed during development, but are currently also installed in production environments. This is undesirable, since both standard and tape have deep dependency trees of their own and result in a lot of unnecessary modules being installed in production environments.