### PR TITLE
Add 'authorization' to secret keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var KEYS = [
   /token/i,
   /api[-._]?key/i,
   /session[-._]?id/i,
+  /authorization/i,
 
   // specific
   /^connect\.sid$/ // https://github.com/expressjs/session

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ test('isSecret.key true', function (t) {
   t.equal(isSecret.key('api.key'), true)
   t.equal(isSecret.key('api_key'), true)
   t.equal(isSecret.key('apikey'), true)
+  t.equal(isSecret.key('authorization'), true)
   t.end()
 })
 


### PR DESCRIPTION
We would like to use this for redacting `Authorization` headers from log winston log output in the manner that is mentioned here: https://github.com/winstonjs/winston/issues/1079