### PR TITLE
fix: handle types that can not be converted to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,29 @@ var VALUES = [
 exports.key = key
 exports.value = value
 
+/**
+ * Converts any input to string.
+ * @data {any} Any JS type of data
+ * @returns string representation of that data or undefined if it can
+ * not be converted into a string.
+ */
+function inputToString (data) {
+  try {
+    return String(data)
+  } catch (err) {
+    if (err instanceof TypeError) return undefined
+    throw err
+  }
+}
+
 function key (str) {
   return KEYS.some(function (regex) {
     return regex.test(str)
   })
 }
 
-function value (str) {
+function value (data) {
+  var str = inputToString(data)
   return VALUES.some(function (regex) {
     return regex.test(str)
   })

--- a/test.js
+++ b/test.js
@@ -1,7 +1,8 @@
 'use strict'
 
-var test = require('tape')
 var isSecret = require('./')
+var test = require('tape')
+var util = require('util')
 
 test('isSecret.key true', function (t) {
   t.equal(isSecret.key('pass'), true)
@@ -30,4 +31,32 @@ test('isSecret.value credt card number', function (t) {
 test('isSecret.value false', function (t) {
   t.equal(isSecret.value('foobar'), false)
   t.end()
+})
+
+// Test all possible JS types minus string
+test('isSecret.value handling of types', function (t1) {
+  var typeTests = [
+    ['array of length 0', [], false],
+    ['boolean as false', false, false],
+    ['boolean as true', true, false],
+    ['function returning undefined', function () {}, false],
+    ['null', null, false],
+    ['number not 16 digits', 42, false],
+    ['number with 16 digits', 4242424242424242, true],
+    ['object with prototype', {}, false],
+    ['object without prototype', Object.create(null), false],
+    ['symbol foo', Symbol('foo'), false],
+    ['undefined', undefined, false]
+  ]
+  typeTests.forEach(function (testData) {
+    var data = testData[1]
+    var expt = testData[2]
+    var desc = util.format('value of %s returns %s', testData[0], expt)
+
+    t1.test(desc, function (t2) {
+      t2.equal(isSecret.value(data), expt)
+      t2.end()
+    })
+  })
+  t1.end()
 })


### PR DESCRIPTION
There was a bug where if a value passed in was not convertible to a
string type, the library would throw

`TypeError: Cannot convert object to primitive value`

Any value that can not be converted to a string can not expose a
secret AFAICT so thus these types should just pass through without
issue. This patch implements that logic and adds tests with all object
types to validate that the function works as expected.